### PR TITLE
remove old pluginrepo preventing builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,13 +132,6 @@
 			<version>19.0</version>
 		</dependency>
 	</dependencies>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>comphenix-rep</id>
-			<name>Comphenix Maven Releases</name>
-			<url>http://repo.comphenix.net/content/groups/public</url>
-		</pluginRepository>
-	</pluginRepositories>
 	<repositories>
 		<repository>
 			<id>Jenkins-repo</id>


### PR DESCRIPTION
old comphenix plugin repo apparently no longer exists or is otherwise unreachable meaning mercury cant be built and thusly neither can anything else. doesn't seem to be used for anything anyway so...